### PR TITLE
Set home to build_dir while sourcing

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,6 +4,10 @@
 # Work in the build directory
 cd $1
 
+# Set HOME to build directory in order to get the bundle command in the PATH
+HOME_BACK=$HOME
+export HOME=$1
+
 # Source in all the profile stuff
 for profile in ./.profile.d/*; do
     . ${profile}
@@ -16,6 +20,9 @@ if [ -d "$3" ]; then
         :
     done
 fi
+
+# Set HOME back to default value
+export HOME=$HOME_BACK
 
 # Just build the static site
 bundle exec middleman build --clean --verbose


### PR DESCRIPTION
Hello,

It seems that heroku `$HOME` and `$1` ( build dir ) are not the same directory anymore during builds.

The `$HOME/vendor/bundle/ruby/2.1.0/bin` is sourced at `/app/vendor/bundle/ruby/2.1.0/bin` but the build directory is something like `/tmp/build_f95cfb33-0a6f-4891-ad78-106d4dd14467` so the bundle binary at `/tmp/build_f95cfb33-0a6f-4891-ad78-106d4dd14467/vendor/bundle/ruby/2.1.0/bin/bundle` is not in the PATH.

I made a little change to set the `$HOME` to the build dir path during the build.

Thanks for that buildpack and thanks for all the greats products from hashicorp.
